### PR TITLE
Null check in listing files

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1246,6 +1246,9 @@ BucketsRouter.prototype.listFilesInBucket = function(req, res, next) {
     var stream = query.cursor();
 
     stream.pipe(utils.createArrayFormatter(function(entry) {
+      if(!entry.frame){
+        return;
+      }
       return {
         bucket: entry.bucket,
         mimetype: entry.mimetype,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,10 @@ var through = require('through');
  */
 module.exports.createArrayFormatter = function(transformer) {
   return through(function(entry) {
+    if(!entry){
+      return;
+    }
+
     if (!this._openBracketWritten) {
       this.queue('[');
       this._openBracketWritten = true;


### PR DESCRIPTION
When I tried to list files in a bucket, I got the following response:

```
Headers:
Connection →keep-alive
Date →Sun, 05 Nov 2017 06:59:52 GMT
Server →nginx/1.11.3
Strict-Transport-Security →max-age=15724800; preload
Transfer-Encoding →chunked
X-Content-Type-Options →nosniff
X-DNS-Prefetch-Control →off
X-Download-Options →noopen
X-Frame-Options →SAMEORIGIN
X-RateLimit-Limit →1000
X-RateLimit-Remaining →999
X-RateLimit-Reset →1509865253
X-XSS-Protection →1; mode=block

Body:
[
```

According to [BucketsRouter.prototype.listFilesInBucket](https://github.com/Storj/bridge/blob/master/lib/server/routes/buckets.js#L1248) and [createArrayFormatter](https://github.com/Storj/bridge/blob/master/lib/utils.js#L13), it seems that `entry.frame` was null and accessing `entry.frame.id` raises an exception, and as the result, only `[` was returned.

This PR adds null check in `BucketsRouter.prototype.listFilesInBucket` and `createArrayFormatter` in order to prevent such exception and return valid JSON texts to clients.